### PR TITLE
Adding libssl-dev libffi-dev

### DIFF
--- a/provision.sh
+++ b/provision.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 sudo apt-get update
-sudo apt-get install -y git python-pip python-dev
+sudo apt-get install -y git python-pip python-dev libssl-dev libffi-dev
 sudo pip install jinja2
 sudo pip install ansible
 


### PR DESCRIPTION
This should allow python cryptography to install without errors
